### PR TITLE
fix report confirmation when no alarm

### DIFF
--- a/src/camera_modules/change_node.py
+++ b/src/camera_modules/change_node.py
@@ -175,7 +175,7 @@ def report(video_path):
     global state_data
 
     if state_id == states.ALARM_REPORT:
-        email_report.send_report_email(state_data['notify_owner'], video_path)
+        email_report.ask_send_report_email(state_data['notify_owner'], video_path)
 
 
 def run():


### PR DESCRIPTION
Problem: when some change observed, video is created, even if there's not a significant enough change for an alarm. Old logic meant the code for confirming email was triggered, which would get stuck as it expects the state ID to be in reporting, while as an alarm hadn't been triggered the state ID was already in moving home.

Solution: check state ID before confirming report.

Closes #104 